### PR TITLE
Add end of the year stats HTML page

### DIFF
--- a/public/2017-end-of-year-stats.html
+++ b/public/2017-end-of-year-stats.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+		<style type="text/css">
+			body {
+				background: green;
+				color: #FFF;
+				font-size: 1.3em;
+				max-width: 800px;
+				margin: auto;
+				font-family: Roboto, sans-serif;
+				line-height: 1.5;
+			}
+			ul {
+				padding: 0;
+				margin: 0 -15px;
+			}
+			li {
+				list-style: none;
+				padding: 25px 15px;
+				border-bottom: 2px solid rgba(255, 255, 255, 0.9);
+			}
+			li:nth-child(2n+1) {
+				background: darkgreen;
+				border-bottom: 2px solid rgba(255, 255, 255, 0.7);
+			}
+			li:last-child {
+				border-bottom: 0;
+			}
+			li:nth-child(2n+1) em {
+				background: rgba(0, 0, 0, 0.3);
+			}
+			em {
+				letter-spacing: 1px;
+				font-style: normal;
+				padding: 2px;
+				font-size: 0.9em;
+				background: darkgreen;
+			}
+			.big {
+				font-size: 1.5em;
+				text-align: center;
+			}
+			.biggest {
+				font-size: 1.8em;
+				text-align: center;
+			}
+
+		</style>
+	</head>
+	<body>
+		<h1>Monday Night Football</h1>
+		<h2>2017 End of year Stats</h2>
+		<ul>
+			<li>This year saw the first match played away from Withdean, at Manor Road in Whitehawk.</li>
+			<li><em>24</em> players played in total in 2017, an increase over 2015 and 2016's total of <em>18</em>.</li>
+			<li>Sam retained <em>1st</em> place from last year, with <em>70pts</em> - a lead of <em>10</em> - but just 1 more than last year's total.</li>
+			<li>Strangely, Sam finished with the exact same goal difference as last year: <em>56</em>.</li>
+			<li>Rob notched a second <em>3rd</em> place finish, whilst Dan improved from <em>4th</em> last year to <em>2nd</em> in 2017.</li>
+			<li>Andy took the top spot for attendance, with an <em>89%</em> attendance record (not enough to beat last year's impressive <em>95%</em> attendance from Chris and Davs).</li>
+			<li>The points per game league was narrowly won by Sam <em>(P39)</em>, on 1.79 PPG. Kris <em>(P21)</em> and Mike <em>(P17)</em> sit 0.03 PPG behind in joint second place. Alex <em>(P10)</em> took 4th place and Dan <em>(P38)</em> took 5th with 1.58.</li>
+			<li>Chris had the biggest consecutive streak of the year, beginning at the start of the year and finishing on 12th June - a total of <em>17</em> appearences.</li>
+			<li>This year saw a marginal decrease in goal difference per game, at <em>3.44</em>, down from  <em>3.67</em> in 2016.</li>
+			<li>2017 saw a decreased proportion of handicap victories - <em>39%</em>, down <em>6%</em> on last year. There were 3 draws this year though, compared to none in 2016.</li>
+			<li class="big"><em>9</em> new players played in 2017, compared to <em>3</em> in 2016.</li>
+			<li class="biggest">This year saw <em>139</em> more goals than last year.</li>
+			<li>7 members joined the century club - Chris, Davs, Sam, Andy, Steve, Rob and Dan. It'll take the best part of a year before we'll likely see another member.</li>
+			<li>Chris increased his lead at the top of the all time attendance list to 10 games, with a total of <em>118</em> appearances.</li>
+			<li>Roscoe moved into the top 10 attendance rankings with <em>49</em> in total, with a <em>70%</em> attendance rate since his debut last year.</li>
+			<li class="big">Sam has now taken top spot from Davs in the overall rankings and holds a 10 point lead.</li>
+		</ul>
+	</body>
+</html>


### PR DESCRIPTION
@davshoward Can you do anything with this to improve it; it's pretty ghetto (screenshot attached)

I know I've got your repo to review and I definitely will, but I wanted to get a page like this up before the end of the year.

<img width="981" alt="screenshot 2017-12-22 13 11 03" src="https://user-images.githubusercontent.com/1331514/34299213-a07d5a3e-e719-11e7-8afa-f2935a21f986.png">
