### PR TITLE
API V2

### DIFF
--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Queries\MatchQuery;
 use App\Queries\PlayerQuery;
 use App\Queries\VenueQuery;
+use App\Queries\SeasonQuery;
 use App\Match;
 use App\Combination;
 use Illuminate\Http\Request;
@@ -37,7 +38,14 @@ class DataController extends Controller
 	public function venues()
 	{
 		return response()->json([
-			"venues" => (new VenueQuery)->get(['name'])
+			'venues' => (new VenueQuery)->get(['name'])
+		]);
+	}
+
+	public function seasons(Request $request, $year)
+	{
+		return response()->json([
+			'season' => (new SeasonQuery($request, $year))->get()
 		]);
 	}
 

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -50,25 +50,6 @@ class DataController extends Controller
 		]);
 	}
 
-	public function combinations(Request $request)
-	{
-		$query = Combination::where('size', '>=', $request->get('minSize', 1))
-			->groupBy('string')
-			->selectRaw('combinations.*, COUNT(*) as occurences')
-			->having('occurences', '>=', $request->get('minOccurences', 0));
-
-		$query = $query->orderBy('occurences', 'desc')->orderBy('size', 'desc');
-
-		return $query->get()->map(function($combination) {
-			return [
-				'size' => $combination->size,
-				'team' => $combination->string,
-				'complete' => $combination->complete ? true : false,
-				'occurences' => $combination->occurences
-			];
-		});
-	}
-
 	protected function v1MatchData()
 	{
 		$matches = Match::with('teams.players', 'venue')->latest('date')->get()->keyBy('id');

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -13,19 +13,10 @@ class DataController extends Controller
 {
 	public function all(Request $request)
 	{
-		$players = (new PlayerQuery($request))->get()->each(function($p) {
-			foreach($p as $k => $v) {
-				$p->$k = is_numeric($v) ? (int)$v : $v;
-			}
-		});
-		$venues = (new VenueQuery)->get(['name']);
-
-		$version = request('v', '2');
-
 		return response()->json([
-			'players' => $players,
-			'matches' => $this->{'v' . $version . 'matchData'}(),
-			'venues' => $venues,
+			'players' => (new PlayerQuery($request))->get(),
+			'matches' => $this->{'v' . request('v', '2') . 'matchData'}(),
+			'venues' => (new VenueQuery)->get(['name']),
 		]);
 	}
 

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -7,6 +7,7 @@ use App\Queries\PlayerQuery;
 use App\Queries\VenueQuery;
 use App\Queries\SeasonQuery;
 use App\Match;
+use App\Team;
 use App\Combination;
 use Illuminate\Http\Request;
 
@@ -79,7 +80,7 @@ class DataController extends Controller
 	protected function v2MatchData()
 	{
 		$matches = (new MatchQuery)->get();
-		$teams = \App\Team::all()->groupBy('match_id');
+		$teams = Team::with('players')->get()->groupBy('match_id');
 
 		return $matches->each(function($match) use ($teams) {
 			foreach($teams[$match->id] as $i => $team) {

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -23,7 +23,7 @@ class DataController extends Controller
 	public function players(Request $request)
 	{
 		return response()->json([
-			'players' => (new PlayerQuery($request))->get($request)
+			'players' => (new PlayerQuery($request))->get()
 		]);
 	}
 

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -41,10 +41,13 @@ class DataController extends Controller
 		]);
 	}
 
-	public function seasons(Request $request, $year)
+	public function seasons(Request $request, $year = null)
 	{
+		$request->show_inactive = true;
+		$request->year = $year;
+
 		return response()->json([
-			'season' => (new SeasonQuery($request, $year))->get()
+			'season' => (new SeasonQuery($request))->get()
 		]);
 	}
 

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -2,44 +2,77 @@
 
 namespace App\Http\Controllers;
 
+use App\Queries\MatchQuery;
+use App\Queries\PlayerQuery;
+use App\Queries\VenueQuery;
 use App\Match;
-use App\Player;
+use App\Combination;
+use Illuminate\Http\Request;
 
 class DataController extends Controller
 {
-	public function json()
+	public function all(Request $request)
 	{
-		$matches = Match::with('teams.players')->latest('date')->get()->keyBy('id');
-		$players = Player::with('teams.match')->get();
+		$players = (new PlayerQuery($request))->get()->each(function($p) {
+			foreach($p as $k => $v) {
+				$p->$k = is_numeric($v) ? (int)$v : $v;
+			}
+		});
+		$venues = (new VenueQuery)->get(['name']);
 
 		$version = request('v', '2');
 
 		return response()->json([
-			'players' => $players->map(function($player) use ($matches) {
-				return [
-					'id' => $player->id,
-					'first_name' => $player->first_name,
-					'last_name' => $player->last_name,
-					'matches' => $player->teams->count(),
-					'wins' => $player->wins(),
-					'losses' => $player->losses(),
-					'draws' => $player->draws(),
-					'scored' => $player->scored(),
-					'conceded' => $matches->sum(function($match) use ($player) {
-						$team = $match->teamPlayedIn($player);
-						return $team ? $match->getOpposition($team)->scored : 0;
-					}),
-					'points' => $player->totalPoints(),
-					'first_appearance' => $matches[$player->teams->first()->match_id]->date->format('Y-m-d'),
-					'last_appearance' => $matches[$player->teams->last()->match_id]->date->format('Y-m-d'),
-				];
-			}),
-			'matches' => $this->{'v' . $version . 'matchData'}($matches)
+			'players' => $players,
+			'matches' => $this->{'v' . $version . 'matchData'}(),
+			'venues' => $venues,
 		]);
 	}
 
-	protected function v1MatchData($matches)
+	public function players(Request $request)
 	{
+		return response()->json([
+			'players' => (new PlayerQuery($request))->get($request)
+		]);
+	}
+
+	public function matches()
+	{
+		return response()->json([
+			'matches' => $this->v2MatchData()
+		]);
+	}
+
+	public function venues()
+	{
+		return response()->json([
+			"venues" => (new VenueQuery)->get(['name'])
+		]);
+	}
+
+	public function combinations(Request $request)
+	{
+		$query = Combination::where('size', '>=', $request->get('minSize', 1))
+			->groupBy('string')
+			->selectRaw('combinations.*, COUNT(*) as occurences')
+			->having('occurences', '>=', $request->get('minOccurences', 0));
+
+		$query = $query->orderBy('occurences', 'desc')->orderBy('size', 'desc');
+
+		return $query->get()->map(function($combination) {
+			return [
+				'size' => $combination->size,
+				'team' => $combination->string,
+				'complete' => $combination->complete ? true : false,
+				'occurences' => $combination->occurences
+			];
+		});
+	}
+
+	protected function v1MatchData()
+	{
+		$matches = Match::with('teams.players', 'venue')->latest('date')->get()->keyBy('id');
+
 		return $matches->map(function($match) {
 			return [
 				'date' => $match->date->format('Y-m-d'),
@@ -63,20 +96,17 @@ class DataController extends Controller
 		});
 	}
 
-	protected function v2MatchData($matches)
+	protected function v2MatchData()
 	{
-		return $matches->map(function($match) {
-			$teams = $match->teams;
-			return [
-				'date' => $match->date->format('Y-m-d'),
-				'short' => $match->is_short == 1,
-				'winner' => $teams[0]->winners ? 'A' : ($teams[0]->draw ? null : 'B'),
-				'handicap' => $teams[0]->handicap ? 'A' : ($teams[1]->handicap ? 'B' : null),
-				'team_a_scored' => $teams[0]->scored,
-				'team_b_scored' => $teams[1]->scored,
-				'team_a' => $teams[0]->playerData(),
-				'team_b' => $teams[1]->playerData(),
-			];
-		})->values();
+		$matches = (new MatchQuery)->get();
+		$teams = \App\Team::all()->groupBy('match_id');
+
+		return $matches->each(function($match) use ($teams) {
+			foreach($teams[$match->id] as $i => $team) {
+				$t = 'team_' . ['a', 'b'][$i];
+				$match->$t = $team->playerData();
+			}
+			unset($match->id);
+		});
 	}
 }

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -7,8 +7,6 @@ use App\Queries\PlayerQuery;
 use App\Queries\VenueQuery;
 use App\Queries\SeasonQuery;
 use App\Match;
-use App\Team;
-use App\Combination;
 use Illuminate\Http\Request;
 
 class DataController extends Controller
@@ -29,10 +27,10 @@ class DataController extends Controller
 		]);
 	}
 
-	public function matches()
+	public function matches(Request $request)
 	{
 		return response()->json([
-			'matches' => $this->v2MatchData()
+			'matches' => $this->v2MatchData($request)
 		]);
 	}
 
@@ -77,17 +75,8 @@ class DataController extends Controller
 		});
 	}
 
-	protected function v2MatchData()
+	protected function v2MatchData($request)
 	{
-		$matches = (new MatchQuery)->get();
-		$teams = Team::with('players')->get()->groupBy('match_id');
-
-		return $matches->each(function($match) use ($teams) {
-			foreach($teams[$match->id] as $i => $team) {
-				$t = 'team_' . ['a', 'b'][$i];
-				$match->$t = $team->playerData();
-			}
-			unset($match->id);
-		});
+		return (new MatchQuery($request))->get();
 	}
 }

--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -15,7 +15,7 @@ class DataController extends Controller
 	{
 		return response()->json([
 			'players' => (new PlayerQuery($request))->get(),
-			'matches' => $this->{'v' . request('v', '2') . 'matchData'}(),
+			'matches' => $this->{'v' . $request->get('v', '2') . 'matchData'}(),
 			'venues' => (new VenueQuery)->get(['name']),
 		]);
 	}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,4 +26,11 @@ Route::resource('teams', 'TeamController');
 Route::get('matches/create', 'AdminController@createMatch');
 Route::post('matches', 'AdminController@storeMatch');
 
-Route::get('data.json', ['middleware' => 'cors', 'uses' => 'DataController@json']);
+Route::group(['middleware' => 'cors'], function() {
+	Route::get('data.json', 'DataController@all');
+	Route::group(['prefix' => 'api'], function() {
+		Route::get('players', 'DataController@players');
+		Route::get('matches', 'DataController@matches');
+		Route::get('venues', 'DataController@venues');
+	});
+});

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -30,7 +30,7 @@ Route::group(['middleware' => 'cors'], function() {
 	Route::get('data.json', 'DataController@all');
 	Route::group(['prefix' => 'api'], function() {
 		Route::get('players', 'DataController@players');
-		Route::resource('seasons', 'DataController@seasons', ['only' => 'show']);
+		Route::resource('seasons', 'DataController@seasons', ['only' => ['show', 'index']]);
 		Route::get('matches', 'DataController@matches');
 		Route::get('venues', 'DataController@venues');
 	});

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -30,6 +30,7 @@ Route::group(['middleware' => 'cors'], function() {
 	Route::get('data.json', 'DataController@all');
 	Route::group(['prefix' => 'api'], function() {
 		Route::get('players', 'DataController@players');
+		Route::resource('seasons', 'DataController@seasons', ['only' => 'show']);
 		Route::get('matches', 'DataController@matches');
 		Route::get('venues', 'DataController@venues');
 	});

--- a/app/Queries/MatchQuery.php
+++ b/app/Queries/MatchQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Queries;
+
+class MatchQuery
+{
+	public function get()
+	{
+$query = <<<SQL
+		SELECT
+		  matches.id,
+		  matches.date,
+		  matches.is_short AS short,
+		  IF(team_a.winners, "A", IF(team_b.winners, "B", null)) AS winner,
+		  IF(team_a.handicap, "A", IF(team_b.handicap, "B", null)) AS handicap,
+		  team_a.scored AS team_a_scored,
+		  team_b.scored AS team_b_scored,
+		  venues.name AS venue
+		FROM matches
+		INNER JOIN teams AS team_a ON team_a.match_id = matches.id
+		INNER JOIN (SELECT team_id, GROUP_CONCAT(player_id) AS player_ids FROM player_team group by team_id) players_a ON team_a.id = players_a.team_id
+		INNER JOIN teams AS team_b ON team_b.match_id = matches.id and team_b.id != team_a.id
+		INNER JOIN venues on venues.id = matches.venue_id
+
+
+
+		GROUP BY matches.id
+SQL;
+		return collect(\DB::select($query));
+	}
+}
+
+// $teams = $match->teams;
+// 			return [
+// 				'date' => $match->date->format('Y-m-d'),
+// 				'short' => $match->is_short == 1,
+// 				'winner' => $teams[0]->winners ? 'A' : ($teams[0]->draw ? null : 'B'),
+// 				'handicap' => $teams[0]->handicap ? 'A' : ($teams[1]->handicap ? 'B' : null),
+// 				'team_a_scored' => $teams[0]->scored,
+// 				'team_b_scored' => $teams[1]->scored,
+// 				'team_a' => $teams[0]->playerData(),
+// 				'team_b' => $teams[1]->playerData(),
+// 				'venue' => $match->venue->name
+// 			];

--- a/app/Queries/MatchQuery.php
+++ b/app/Queries/MatchQuery.php
@@ -21,9 +21,6 @@ $query = <<<SQL
 		INNER JOIN (SELECT team_id, GROUP_CONCAT(player_id) AS player_ids FROM player_team group by team_id) players_a ON team_a.id = players_a.team_id
 		INNER JOIN teams AS team_b ON team_b.match_id = matches.id and team_b.id != team_a.id
 		INNER JOIN venues on venues.id = matches.venue_id
-
-
-
 		GROUP BY matches.id
 SQL;
 		return collect(\DB::select($query));

--- a/app/Queries/MatchQuery.php
+++ b/app/Queries/MatchQuery.php
@@ -2,8 +2,19 @@
 
 namespace App\Queries;
 
+use Illuminate\Http\Request;
+use App\Team;
+use DateTime;
+
 class MatchQuery
 {
+	protected $request;
+
+	public function __construct(Request $request)
+	{
+		$this->request = $request;
+	}
+
 	public function get()
 	{
 $query = <<<SQL
@@ -13,6 +24,7 @@ $query = <<<SQL
 		  matches.is_short AS short,
 		  IF(team_a.winners, "A", IF(team_b.winners, "B", null)) AS winner,
 		  IF(team_a.handicap, "A", IF(team_b.handicap, "B", null)) AS handicap,
+		  COUNT(player_team.id) AS total_players,
 		  team_a.scored AS team_a_scored,
 		  team_b.scored AS team_b_scored,
 		  venues.name AS venue
@@ -20,8 +32,45 @@ $query = <<<SQL
 		INNER JOIN teams AS team_a ON team_a.match_id = matches.id
 		INNER JOIN teams AS team_b ON team_b.match_id = matches.id and team_b.id != team_a.id
 		INNER JOIN venues on venues.id = matches.venue_id
+		INNER JOIN player_team on player_team.team_id = team_a.id
+		WHERE date >= ? AND date <= ?
 		GROUP BY matches.id
 SQL;
-		return collect(\DB::select($query));
+		$teams = Team::with('players')->get()->groupBy('match_id');
+
+		return collect(\DB::select($query, [$this->fromDate(), $this->toDate()]))->each(function($match) use ($teams) {
+			$match->short = (boolean)$match->short;
+
+			foreach($teams[$match->id] as $i => $team) {
+				$t = 'team_' . ['a', 'b'][$i];
+				$match->$t = $team->playerData();
+			}
+			unset($match->id);
+		});
+	}
+
+	protected function fromDate()
+	{
+		if ($this->request->year) {
+			return (new DateTime)->setDate($this->request->year, 1, 1);
+		}
+
+		return "2015-01-01";
+	}
+
+	protected function toDate()
+	{
+		if ( ! $this->request->year) {
+			return new DateTime($this->request->to);
+		}
+
+		$to = new DateTime;
+
+		if ($to->format('Y') > $this->request->year) {
+			$to->setDate($this->request->year, 12, 31);
+		}
+
+		return $to;
+
 	}
 }

--- a/app/Queries/MatchQuery.php
+++ b/app/Queries/MatchQuery.php
@@ -26,16 +26,3 @@ SQL;
 		return collect(\DB::select($query));
 	}
 }
-
-// $teams = $match->teams;
-// 			return [
-// 				'date' => $match->date->format('Y-m-d'),
-// 				'short' => $match->is_short == 1,
-// 				'winner' => $teams[0]->winners ? 'A' : ($teams[0]->draw ? null : 'B'),
-// 				'handicap' => $teams[0]->handicap ? 'A' : ($teams[1]->handicap ? 'B' : null),
-// 				'team_a_scored' => $teams[0]->scored,
-// 				'team_b_scored' => $teams[1]->scored,
-// 				'team_a' => $teams[0]->playerData(),
-// 				'team_b' => $teams[1]->playerData(),
-// 				'venue' => $match->venue->name
-// 			];

--- a/app/Queries/MatchQuery.php
+++ b/app/Queries/MatchQuery.php
@@ -18,7 +18,6 @@ $query = <<<SQL
 		  venues.name AS venue
 		FROM matches
 		INNER JOIN teams AS team_a ON team_a.match_id = matches.id
-		INNER JOIN (SELECT team_id, GROUP_CONCAT(player_id) AS player_ids FROM player_team group by team_id) players_a ON team_a.id = players_a.team_id
 		INNER JOIN teams AS team_b ON team_b.match_id = matches.id and team_b.id != team_a.id
 		INNER JOIN venues on venues.id = matches.venue_id
 		GROUP BY matches.id

--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -76,7 +76,11 @@ SQL;
 	protected function toDate()
 	{
 		if ($this->request->year) {
-			return (new DateTime)->setDate($this->request->year, 12, 31);
+			$to = new DateTime;
+			if ($to->format('Y') > $this->request->year) {
+				$to->setDate($this->request->year, 12, 31);
+			}
+			return $to;
 		}
 
 		return new DateTime($this->request->get('to'));

--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -75,15 +75,17 @@ SQL;
 
 	protected function toDate()
 	{
-		if ($this->request->year) {
-			$to = new DateTime;
-			if ($to->format('Y') > $this->request->year) {
-				$to->setDate($this->request->year, 12, 31);
-			}
-			return $to;
+		if ( ! $this->request->year) {
+			return new DateTime($this->request->to);
 		}
 
-		return new DateTime($this->request->get('to'));
+		$to = new DateTime;
+
+		if ($to->format('Y') > $this->request->year) {
+			$to->setDate($this->request->year, 12, 31);
+		}
+
+		return $to;
 	}
 
 	protected function inactiveDate()

--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -26,6 +26,7 @@ $query = <<<SQL
 			SUM(conceded) AS conceded,
 			SUM(scored) - SUM(conceded) AS gd,
 			SUM(wins) * 3 + SUM(draws) AS points,
+			ROUND((SUM(wins) * 3 + SUM(draws)) / SUM(matches), 2) AS ppg,
 			MIN(date) AS first_appearance,
 			MAX(date) AS last_appearance
 		FROM players

--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -26,21 +26,18 @@ $query = <<<SQL
 			SUM(conceded) AS conceded,
 			SUM(scored) - SUM(conceded) AS gd,
 			SUM(wins) * 3 + SUM(draws) AS points,
-			SUM(wins) * 3 + SUM(draws) AS points,
 			MIN(date) AS first_appearance,
 			MAX(date) AS last_appearance
 		FROM players
 		INNER JOIN player_team ON player_team.player_id = players.id
 		INNER JOIN (
-			SELECT matches.date AS date, MAX(matches.date), teams.id, match_id, COUNT(matches.id) AS matches, sum(draw) AS draws, sum(winners) AS wins, SUM(scored) as scored
+			SELECT matches.date, teams.id, teams.match_id, 1 AS matches, draw AS draws, winners AS wins, scored
 			FROM teams
 			INNER JOIN matches on matches.id = teams.match_id
-			GROUP BY teams.id
 		) team_a ON team_a.id = player_team.team_id
 		INNER JOIN (
-			SELECT id, match_id, sum(winners) AS losses, SUM(scored) AS conceded
+			SELECT id, match_id, winners AS losses, scored AS conceded
 			FROM teams
-			GROUP BY teams.id
 		) team_b ON team_b.match_id = team_a.match_id AND team_a.id != team_b.id
 		WHERE date >= ? AND date <= ?
 		GROUP BY players.id

--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -50,7 +50,8 @@ SQL;
 
 		return collect(\DB::select($query, $placeholders))->each(function($p) {
 			foreach($p as $k => $v) {
-				$p->$k = is_numeric($v) ? (int)$v : $v;
+				if (is_numeric($v) == false) continue;
+				$p->$k = strpos($v, '.') === false ? (int)$v : (float)$v;
 			}
 		});
 	}

--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Queries;
+
+use DateTime, DateInterval;
+
+class PlayerQuery
+{
+	public function __construct($request)
+	{
+		$this->request = $request;
+	}
+
+	public function get()
+	{
+$query = <<<SQL
+		SELECT
+			players.id,
+			players.first_name,
+			players.last_name,
+			SUM(matches) AS matches,
+			SUM(wins) AS wins,
+			SUM(losses) AS losses,
+			SUM(draws) AS draws,
+			SUM(scored) AS scored,
+			SUM(conceded) AS conceded,
+			SUM(scored) - SUM(conceded) AS gd,
+			SUM(wins) * 3 + SUM(draws) AS points,
+			SUM(wins) * 3 + SUM(draws) AS points,
+			MIN(date) AS first_appearance,
+			MAX(date) AS last_appearance
+		FROM players
+		INNER JOIN player_team ON player_team.player_id = players.id
+		INNER JOIN (
+			SELECT matches.date AS date, MAX(matches.date), teams.id, match_id, COUNT(matches.id) AS matches, sum(draw) AS draws, sum(winners) AS wins, SUM(scored) as scored
+			FROM teams
+			INNER JOIN matches on matches.id = teams.match_id
+			WHERE matches.date >= ?
+			GROUP BY teams.id
+		) team_a ON team_a.id = player_team.team_id
+		INNER JOIN (
+			SELECT id, match_id, sum(winners) AS losses, SUM(scored) AS conceded
+			FROM teams
+			GROUP BY teams.id
+		) team_b ON team_b.match_id = team_a.match_id AND team_a.id != team_b.id
+		GROUP BY players.id
+		HAVING last_appearance >= ? AND matches >= ?
+		ORDER BY points desc, matches ASC, gd DESC, scored DESC
+SQL;
+
+		$placeholders = [$this->fromDate(), $this->inactiveDate(), $this->minMatches()];
+
+		return collect(\DB::select($query, $placeholders))->each(function($p) {
+			foreach($p as $k => $v) {
+				$p->$k = is_numeric($v) ? (int)$v : $v;
+			}
+		});
+	}
+
+	protected function fromDate()
+	{
+		if ($this->request->since) {
+			return $this->request->since;
+		}
+
+		if ($this->request->last) {
+			return (new DateTime)->sub(new DateInterval('P' . $this->request->last));
+		}
+
+		if ($this->request->year) {
+			return (new DateTime)->setDate($this->request->year, 1, 1);
+		}
+
+		return "2015-01-01";
+	}
+
+	protected function inactiveDate()
+	{
+		return $this->request->show_inactive ? '2015-01-01' : new DateTime('10 weeks ago');
+	}
+
+	protected function minMatches()
+	{
+		return $this->request->get("min_matches", 1);
+	}
+}

--- a/app/Queries/SeasonQuery.php
+++ b/app/Queries/SeasonQuery.php
@@ -71,7 +71,7 @@ SQL;
 
 		$to = new DateTime;
 
-		if ($to->format('Y') > $this->request->year) {
+		if ($this->seasonHasEnded()) {
 			$to->setDate($this->request->year, 12, 31);
 		}
 

--- a/app/Queries/SeasonQuery.php
+++ b/app/Queries/SeasonQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Queries;
+
+use DateTime;
+use Illuminate\Http\Request;
+
+class SeasonQuery
+{
+	public function __construct(Request $request, $year)
+	{
+		$request->year = $year;
+		$this->request = $request;
+	}
+
+	public function get()
+	{
+		$players = (new PlayerQuery($this->request))->get();
+
+		return [
+			'year' => $this->request->year,
+			'start_date' => $players->min('first_appearance'),
+			'end_date' => $this->seasonHasEnded() ? $players->max('last_appearance') : null,
+			'total_matches' => $this->matchCount(),
+			'players' => $players
+		];
+	}
+
+	protected function seasonHasEnded()
+	{
+		return $this->request->year < (new DateTime)->format('Y');
+	}
+
+	protected function matchCount()
+	{
+		return \DB::selectOne("SELECT COUNT(id) AS count FROM matches where YEAR(date) = ?", [
+			$this->request->year
+		])->count;
+	}
+}

--- a/app/Queries/SeasonQuery.php
+++ b/app/Queries/SeasonQuery.php
@@ -40,9 +40,10 @@ SQL;
 
 		$placeholders = [$this->request->year ?: "all", $this->fromDate(), $this->toDate()];
 
-		return collect(\DB::selectOne($query, $placeholders))->merge([
-			'leaderboard' => $this->players->get(),
-		])->merge($this->matches())->merge($this->endDate());
+		return collect(\DB::selectOne($query, $placeholders))
+			->merge(['leaderboard' => $this->players->get()])
+			->merge($this->matches())
+			->merge($this->endDate());
 	}
 
 	protected function matches()

--- a/app/Queries/SeasonQuery.php
+++ b/app/Queries/SeasonQuery.php
@@ -7,35 +7,41 @@ use Illuminate\Http\Request;
 
 class SeasonQuery
 {
+	protected $players;
+	protected $matches;
+	protected $year;
+
 	public function __construct(Request $request, $year)
 	{
 		$request->year = $year;
-		$this->request = $request;
+		$this->year = $year;
+		$this->players = new PlayerQuery($request);
+		$this->matches = new MatchQuery($request);
 	}
 
 	public function get()
 	{
-		$players = (new PlayerQuery($this->request))->get();
+		$players = $this->players->get();
 
 		return [
-			'year' => $this->request->year,
+			'year' => $this->year,
 			'start_date' => $players->min('first_appearance'),
 			'end_date' => $this->seasonHasEnded() ? $players->max('last_appearance') : null,
 			'total_matches' => $this->matchCount(),
-			'matches' => (new MatchQuery($this->request))->get(),
+			'matches' => $this->matches->get(),
 			'leaderboard' => $players
 		];
 	}
 
 	protected function seasonHasEnded()
 	{
-		return $this->request->year < (new DateTime)->format('Y');
+		return $this->year < (new DateTime)->format('Y');
 	}
 
 	protected function matchCount()
 	{
 		return \DB::selectOne("SELECT COUNT(id) AS count FROM matches where YEAR(date) = ?", [
-			$this->request->year
+			$this->year
 		])->count;
 	}
 }

--- a/app/Queries/SeasonQuery.php
+++ b/app/Queries/SeasonQuery.php
@@ -22,7 +22,8 @@ class SeasonQuery
 			'start_date' => $players->min('first_appearance'),
 			'end_date' => $this->seasonHasEnded() ? $players->max('last_appearance') : null,
 			'total_matches' => $this->matchCount(),
-			'players' => $players
+			'matches' => (new MatchQuery($this->request))->get(),
+			'leaderboard' => $players
 		];
 	}
 

--- a/app/Queries/VenueQuery.php
+++ b/app/Queries/VenueQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Queries;
+
+class VenueQuery
+{
+	public function get($fields = ['*'])
+	{
+		$fields = collect($fields)->map(function($field) { return 'venues.' . $field; })->implode(', ');
+
+$query = <<<EOT
+		SELECT {$fields}, COUNT(matches.id) as matches, MIN(date) AS first_match
+		FROM venues
+		INNER JOIN matches ON matches.venue_id = venues.id
+		GROUP BY venues.id
+EOT;
+		return \DB::select($query);
+	}
+}

--- a/app/Team.php
+++ b/app/Team.php
@@ -72,11 +72,11 @@ class Team extends Model
 
 	public function playerData()
 	{
-		return [
-			'ids' => $this->players->pluck('id'),
-			'names' => $this->players->map(function($p) {
-				return $p->shortName();
-			})
-		];
+		return $this->players->map(function($p) {
+			return [
+				'id' => $p->id,
+				'name' => $p->shortName(),
+			];
+		});
 	}
 }


### PR DESCRIPTION
This pull request refactors and improves performance of the current /data.json end point. It also adds venue data, goal difference (gd) and points per game (ppg) to the result.

In addition, it adds the following end-points:

- /api/players
- /api/matches
- /api/venues
- /api/seasons/{year}

## Players
You can filter the players list with the following options in the query string:

- `from={YYYY-MM-DD}`
- `to={YYYY-MM-DD}`
- `year={YYYY}`
- `last={INTERVAL}` (where {INTERVAL} is a recognised `DateInterval` format in PHP:  http://php.net/manual/en/dateinterval.construct.php, e.g. 2W, 6M, 1Y)
- `show_inactive=1`
- `minMatches={INT}`

Note: by default, inactive players (haven't played in 10 weeks previous to the "to" date param, which defaults to today) are hidden.