### PR TITLE
Player season end point

### DIFF
--- a/app/PlayerStreak.php
+++ b/app/PlayerStreak.php
@@ -59,11 +59,6 @@ class PlayerStreak
 		});
 	}
 
-	public function active()
-	{
-		return array_key_exists("apps", $this->streaks);
-	}
-
 	protected function hit($type, $match)
 	{
 		$this->currentStreak($type, $match)->extend($match->date);

--- a/app/Queries/Filters/InactiveDate.php
+++ b/app/Queries/Filters/InactiveDate.php
@@ -13,6 +13,8 @@ class InactiveDate
 
 	function get($request)
 	{
-		return $request->show_inactive ? '2015-01-01' : $this->toDate->get($request)->sub(new DateInterval('P10W'));
+		if ($request->show_inactive || $request->player) return '2015-01-01';
+
+		return $this->toDate->get($request)->sub(new DateInterval('P10W'));
 	}
 }

--- a/app/Queries/FormQuery.php
+++ b/app/Queries/FormQuery.php
@@ -6,13 +6,20 @@ use App\Match;
 
 class FormQuery
 {
+	protected $request;
+	protected $query = [];
+
 	public function __construct($request)
 	{
 		$this->request = $request;
 	}
 
-	public function get()
+	public function get($byYear = null)
 	{
+		if (array_key_exists($byYear, $this->query)) {
+			return $this->query[$byYear];
+		}
+
 		$placeholders = [
 			(new Filters\FromDate)->get($this->request),
 			(new Filters\ToDate)->get($this->request),
@@ -20,11 +27,13 @@ class FormQuery
 
 		$matches = Match::with('teams.players')
 			->whereRaw('date >= ? AND date <= ?', $placeholders)
-			->latest('date')->take($this->limit())->get();
+			->latest('date')->take($this->limit());
 
-		return $matches->map(function($match) {
-			return $match->playerResults();
-		});
+		if ($byYear) {
+			$matches->whereRaw('YEAR(date) = ?', [$byYear]);
+		}
+
+		return $this->query[$byYear] = $matches->get()->map->playerResults();
 	}
 
 	protected function limit()

--- a/app/Queries/MatchQuery.php
+++ b/app/Queries/MatchQuery.php
@@ -19,6 +19,7 @@ class MatchQuery
 		$query = <<<SQL
 		SELECT
 		  matches.id,
+		  YEAR(matches.date) AS year,
 		  matches.date,
 		  matches.is_short AS short,
 		  matches.is_void AS voided,
@@ -48,9 +49,10 @@ SQL;
 		return collect(\DB::select($query, $placeholders))->each(function($match) use ($teams) {
 			$match->short = (boolean)$match->short;
 			$match->voided = (boolean)$match->voided;
-			$match->team_a = $teams[$match->id][0]->playerData();
-			$match->team_b = $teams[$match->id][1]->playerData();
-
+			if ( ! $this->request->hide_teams) {
+				$match->team_a = $teams[$match->id][0]->playerData();
+				$match->team_b = $teams[$match->id][1]->playerData();
+			}
 			unset($match->id);
 		});
 	}

--- a/app/Queries/PlayerResultQuery.php
+++ b/app/Queries/PlayerResultQuery.php
@@ -17,7 +17,9 @@ class PlayerResultQuery
 
 	public function getByYear($year)
 	{
-		return $this->get()->groupBy('year')->get($year);
+		return $this->get()->groupBy('year')->get($year)->each(function($result) {
+			unset($result->year);
+		});
 	}
 
 	public function get()

--- a/app/Queries/PlayerResultQuery.php
+++ b/app/Queries/PlayerResultQuery.php
@@ -8,18 +8,34 @@ use App\Team;
 class PlayerResultQuery
 {
 	protected $request;
+	protected $query;
 
 	public function __construct(Request $request)
 	{
 		$this->request = $request;
 	}
 
+	public function getByYear($year)
+	{
+		return $this->get()->groupBy('year')->get($year);
+	}
+
 	public function get()
+	{
+		if (is_null($this->query)) {
+			$this->query = $this->query();
+		}
+
+		return $this->query;
+	}
+
+	protected function query()
 	{
 		$query = <<<SQL
 		SELECT
 		  matches.id,
 		  matches.date,
+		  YEAR(matches.date) AS year,
 		  matches.is_short AS short,
 		  matches.is_void AS voided,
 		  IF(teams.winners, "Win", IF(opps.winners, "Loss", IF (teams.draw, "Draw", ""))) AS result,

--- a/app/Queries/PlayerResultQuery.php
+++ b/app/Queries/PlayerResultQuery.php
@@ -55,7 +55,7 @@ class PlayerResultQuery
 		INNER JOIN player_team ON player_team.team_id = teams.id
 		INNER JOIN players ON players.id = player_team.player_id
 		WHERE date >= ? AND date <= ? AND players.id = ?
-		GROUP BY matches.id
+		GROUP BY teams.id, opps.id
 		ORDER BY matches.date, matches.id
 SQL;
 		$placeholders = [

--- a/app/Queries/RankQuery.php
+++ b/app/Queries/RankQuery.php
@@ -32,7 +32,7 @@ class RankQuery
 		SELECT
 		  year(date) AS year,
 		  players.*,
-		  SUM(teams.winners) * 3 + SUM(teams.draw) AS pts,
+		  SUM(IF(teams.winners, 3, 0)) + SUM(IF(teams.draw, 1, 0)) AS pts,
 		  SUM(teams.scored) - SUM(opps.scored) AS gd,
 		  COUNT(teams.id) as apps
 		FROM matches
@@ -40,7 +40,7 @@ class RankQuery
 		INNER JOIN teams opps ON opps.match_id = matches.id AND teams.id != opps.id
 		INNER JOIN player_team pt ON pt.team_id = teams.id
 		INNER JOIN players ON players.id = pt.player_id
-		WHERE is_void = 0 AND date >= ? AND date <= ?
+		WHERE date >= ? AND date <= ?
 		GROUP BY year(date), players.id
 		ORDER BY year, pts DESC, gd DESC, apps ASC
 SQL;

--- a/app/Queries/SinglePlayerQuery.php
+++ b/app/Queries/SinglePlayerQuery.php
@@ -25,6 +25,7 @@ class SinglePlayerQuery
 
 		unset($player->first_name);
 
+		$player->results = $this->results->get();
 		$player->streaks = $this->streaks->getByYear('all')->topStreaksByType();
 
 		$player->seasons = $this->player->getSeasons()->each(function($season, $year) {

--- a/app/Queries/SinglePlayerQuery.php
+++ b/app/Queries/SinglePlayerQuery.php
@@ -9,8 +9,6 @@ class SinglePlayerQuery
 
 	public function __construct($request)
 	{
-		$request->show_inactive = true;
-
 		$this->player = new PlayerQuery($request);
 		$this->rank = new RankQuery($request);
 		$this->streaks = new PlayerStreakQuery($request);

--- a/app/Queries/VenueQuery.php
+++ b/app/Queries/VenueQuery.php
@@ -26,12 +26,10 @@ $query = <<<EOT
 
 EOT;
 
-		$matches = $this->matches->get();
+		$matches = $this->matches->get()->groupBy('venue');
 
 		return collect(\DB::select($query))->each(function($venue) use ($matches) {
-			$venue->matches = $matches->filter(function($match) use ($venue) {
-				return $match->venue == $venue->name;
-			});
+			$venue->matches = $matches->get($venue->name);
 		});
 	}
 }


### PR DESCRIPTION
This adds a "seasons" field to the single player end-point, which contains all the stats, results, streaks and ranking for each season. Format:

```
{
  player: {
    id
    first_initial
    matches
    wins
    ...
    results: [
      {
        date
        result
        ...
      }
    ]
    streaks: {
      apps: [
        {
          count
          from
          to
        }
        ...
      ]
    }
    seasons: {
      2015: {
        matches
        wins
        losses
        ...
        ranking
        results: [
          ...
        ]
        streaks: {
          apps: [
            ...
          ]
        }
      }
    }
  }
}
```