### PR TITLE
Fix broken setup-php action pin

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: shivammathur/setup-php@b7d1d9c9a92d8d8463ce36d7f60da34d461724f8
+    - uses: shivammathur/setup-php@v2
       with:
         php-version: '8.0'
     - uses: actions/checkout@v2


### PR DESCRIPTION
Update shivammathur/setup-php from a commit hash that no longer exists to the stable @v2 tag.