### PR TITLE
Remove hard match limit in PlayerQuery

### DIFF
--- a/app/Queries/PlayerQuery.php
+++ b/app/Queries/PlayerQuery.php
@@ -26,6 +26,7 @@ class PlayerQuery
 	public function get($yearField = 'NULL', $group = 'players.id', $order = self::DEFAULT_ORDER)
 	{
 		$where = $this->request->player ? "WHERE players.id = ?" : "";
+		$limit = $this->request->match_limit ? "LIMIT ?" : "";
 
 $query = <<<SQL
 		SELECT
@@ -78,7 +79,7 @@ $query = <<<SQL
 			INNER JOIN matches on matches.id = teams.match_id
 			WHERE date >= ? AND date <= ?
 			ORDER BY matches.date desc
-			LIMIT ?
+			{$limit}
 		) team_a ON team_a.id = player_team.team_id
 		INNER JOIN (
 			SELECT
@@ -144,8 +145,6 @@ SQL;
 	{
 		if ($this->request->match_limit) {
 			return $this->request->match_limit * 2;
-		} else {
-			return 999;
 		}
 	}
 


### PR DESCRIPTION
Fixes issue when showing 2015 season stats on a player query, where some matches are cut off. There was a hard 999 limit (which excludes matches over 500).