### PR TITLE
Add podium medal badges to player pages

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -391,6 +391,23 @@ nav a {
 
 h2 small { font-size: 0.7em; color: #666; }
 
+.badges { display: flex; gap: 8px; margin: 0 0 1em; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: bold;
+  color: #3a2f00;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+}
+.badge__year { font-weight: normal; opacity: 0.8; }
+.badge--gold { background: linear-gradient(#ffe27a, #f5c518); }
+.badge--silver { background: linear-gradient(#f0f0f0, #c4c4c4); color: #333; }
+.badge--bronze { background: linear-gradient(#e6a86b, #cd7f32); color: #3a2400; }
+
 @media only screen and (max-width: 600px) {
   body {
     margin: 1em;

--- a/resources/views/players/show.blade.php
+++ b/resources/views/players/show.blade.php
@@ -7,6 +7,29 @@
 	{{ $player->first_initial }} {{ $player->last_name }}
 </h2>
 
+@php
+	$medals = [
+		1 => ['label' => '1st', 'class' => 'gold'],
+		2 => ['label' => '2nd', 'class' => 'silver'],
+		3 => ['label' => '3rd', 'class' => 'bronze'],
+	];
+
+	// Only count finishes from completed seasons (exclude the current, in-progress year).
+	$podiums = $player->seasons->filter(fn($s, $year) => $year < now()->year && $s->ranking >= 1 && $s->ranking <= 3);
+@endphp
+
+@if ($podiums->isNotEmpty())
+	<div class="badges">
+		@foreach ($medals as $rank => $medal)
+			@foreach ($podiums->filter(fn($s) => $s->ranking == $rank)->sortKeys() as $year => $season)
+				<span class="badge badge--{{ $medal['class'] }}" title="{{ $medal['label'] }} place in {{ $year }}">
+					{{ $medal['label'] }} <span class="badge__year">{{ $year }}</span>
+				</span>
+			@endforeach
+		@endforeach
+	</div>
+@endif
+
 <table class="leaderboard">
 	<thead>
 		<tr>


### PR DESCRIPTION
## What

Adds gold / silver / bronze medal badges to a player's profile page, one for each season they finished 1st, 2nd, or 3rd.

<img width="760" height="250" alt="Podium badges on a player page" src="https://github.com/user-attachments/assets/78c06595-de58-4255-87d3-4a025a6434f6" />

## Details

- Badges are grouped by medal (all golds, then silvers, then bronzes) and ordered by year within each group.
- Only **completed** seasons count — the in-progress current year is excluded, so a player can't earn a badge for a season that hasn't finished.
- Players with no podium finishes show nothing (no empty container).
- Styling lives in `public/css/app.css` (`.badges` / `.badge` / `.badge--{gold,silver,bronze}`); markup is in `resources/views/players/show.blade.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)